### PR TITLE
feat: add automated PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - development
+
+jobs:
+  publish-stable:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.4"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always
+
+  publish-dev:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: dev-pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.4"
+
+      - name: Patch version with dev suffix
+        run: |
+          python3 -c "
+          import re, pathlib
+          p = pathlib.Path('pyproject.toml')
+          content = p.read_text()
+          content = re.sub(r'(version = \"\d+\.\d+\.\d+)\"', r'\1.dev${{ github.run_number }}\"', content)
+          p.write_text(content)
+          "
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always


### PR DESCRIPTION
Creates .github/workflows/publish.yml with two jobs:
- publish-stable: triggered by GitHub Release published, uses version
  from pyproject.toml as-is, environment 'pypi'
- publish-dev: triggered by push to development branch, patches version
  with .dev{run_number} suffix (PEP 440), environment 'dev-pypi'

Both jobs use OIDC Trusted Publishing (no API tokens required).

Requires one-time Trusted Publisher setup on PyPI:
  Owner: A-Fisk, Repo: circaPy, Workflow: publish.yml
  Environments: pypi (stable), dev-pypi (dev builds)

Closes #38

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
