### PR TITLE
Claude/review open issues ywe2 z

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ CircaPy is a python module for circadian analysis of activity data.
 It was developed using laboratory
 rodents data but is applicable across species and monitoring devices.
 
+Full documentation is available at [circapy.readthedocs.io](https://circapy.readthedocs.io)
+
 A limited version is available as an [interactive
 website](https://circapywebsite.streamlit.app/)
 

--- a/circaPy/activity.py
+++ b/circaPy/activity.py
@@ -328,7 +328,7 @@ def calculate_IS(data):
 
 
 @prep.validate_input
-def calculate_TV(data, subject_no=0):
+def calculate_TV(data, col=0):
     r"""
     Calculates Timepoint Variability
 
@@ -363,7 +363,7 @@ def calculate_TV(data, subject_no=0):
     The TV value ranges from 0 to 1, lower is more stable.
     """
     # select the data
-    curr_data = data.iloc[:, subject_no]
+    curr_data = data.iloc[:, col]
 
     # calculate mean
     mean_data = calculate_mean_activity(curr_data)

--- a/circaPy/episodes.py
+++ b/circaPy/episodes.py
@@ -19,7 +19,7 @@ import circaPy.preprocessing as prep
 
 @prep.validate_input
 def find_episodes(
-    data, subject_no=0, min_length="1s", max_interruption="0s", *args, **kwargs
+    data, col=0, min_length="1s", max_interruption="0s", *args, **kwargs
 ):
     """
     Identifies episodes in a time series of activity data for a specific subject,
@@ -31,7 +31,7 @@ def find_episodes(
     data : pd.DataFrame
         The activity data for multiple subjects, where each column represents
         a subject's activity over time, and the index is a time-based index.
-    subject_no : int, optional
+    col : int, optional
         The column index of the subject to analyze. Default is 0.
     min_length : str or pandas.Timedelta, optional
         The minimum duration for an episode to be included in the results.
@@ -62,13 +62,13 @@ def find_episodes(
     ...     "Subject 1": np.random.choice([0, 1], size=100, p=[0.8, 0.2]),
     ...     "Subject 2": np.random.choice([0, 1], size=100, p=[0.7, 0.3]),
     ... }, index=index)
-    >>> find_episodes(data, subject_no=0, min_length="3s", max_interruption="2s")
+    >>> find_episodes(data, col=0, min_length="3s", max_interruption="2s")
     2024-01-01 00:00:15    7.0
     2024-01-01 00:00:45    5.0
     dtype: float64
     """
     # select single column
-    curr_data = data.iloc[:, subject_no]
+    curr_data = data.iloc[:, col]
 
     # Determine the threshold for episode identification
     zero_data = curr_data == 0

--- a/circaPy/periodogram.py
+++ b/circaPy/periodogram.py
@@ -9,7 +9,7 @@ import circaPy.preprocessing as prep
 
 
 @prep.validate_input
-def lomb_scargle_period(data, subject_no=0, low_period=20, high_period=30, **kwargs):
+def lomb_scargle_period(data, col=0, low_period=20, high_period=30, **kwargs):
     """
     Calculates the Lomb-Scargle periodogram for a single column in a DataFrame.
 
@@ -18,7 +18,7 @@ def lomb_scargle_period(data, subject_no=0, low_period=20, high_period=30, **kwa
     data : pd.DataFrame
         Input DataFrame with time-series data. The index represents time, and
         the columns contain observations.
-    subject_no : int, optional
+    col : int, optional
         The positional index of the column to analyze. Default is 0.
     low_period : float, optional
         The shortest period to search for, in hours. Default is 20.
@@ -42,7 +42,7 @@ def lomb_scargle_period(data, subject_no=0, low_period=20, high_period=30, **kwa
     Raises
     ------
     IndexError
-        If `subject_no` is out of the valid range for the DataFrame columns.
+        If `col` is out of the valid range for the DataFrame columns.
     ValueError
         If `low_period` is greater than or equal to `high_period`.
 
@@ -58,9 +58,9 @@ def lomb_scargle_period(data, subject_no=0, low_period=20, high_period=30, **kwa
       contains only NaNs.
     """
     # Ensure the positional index is valid
-    if subject_no < 0 or subject_no >= len(data.columns):
+    if col < 0 or col >= len(data.columns):
         raise IndexError(
-            f"Invalid subject_no {subject_no}. Must be between 0 and"
+            f"Invalid col {col}. Must be between 0 and"
             f"{len(data.columns) - 1}."
         )
 
@@ -80,7 +80,7 @@ def lomb_scargle_period(data, subject_no=0, low_period=20, high_period=30, **kwa
     freq_hours = 1 / (freq * 3600)
 
     # Prepare observations
-    observations = data.iloc[:, subject_no].values
+    observations = data.iloc[:, col].values
     observation_times = np.arange(len(data)) * sample_freq
 
     # Check if all NaN

--- a/circaPy/plots.py
+++ b/circaPy/plots.py
@@ -14,7 +14,7 @@ import circaPy.preprocessing as prep
 @prep.plot_kwarg_decorator
 def plot_actogram(
     data,
-    subject_no=0,
+    col=0,
     light_col=-1,
     ylim=[0, 120],
     fig=False,
@@ -37,7 +37,7 @@ def plot_actogram(
         columns for each subject and one column for the light levels.
         WRONG - currently expecting list of dataframes, one for each animal
         and single column for each day
-    subject_no : int
+    col : int
         which column number to plot, defaults to 0
     light_col : int
         which columns contains light information, defaults to -1
@@ -80,7 +80,7 @@ def plot_actogram(
         raise ValueError("Input Dataframe is empty. Cannot plot actogram")
 
     # select the correct data to plot for activity and light
-    col_data = data.columns[subject_no]
+    col_data = data.columns[col]
     ldr_col = data.columns[light_col]
     data_plot = data.loc[:, col_data].copy()
     data_light = data.loc[:, ldr_col].copy()

--- a/tests/activity_tests.py
+++ b/tests/activity_tests.py
@@ -492,15 +492,15 @@ class TestCalculateTV(unittest.TestCase):
 
     def test_calculate_tv_basic(self):
         """Test calculate_TV with valid data."""
-        tv_value = calculate_TV(self.data, subject_no=0)
+        tv_value = calculate_TV(self.data, col=0)
         self.assertIsInstance(tv_value, float, "The result should be a float.")
         self.assertGreaterEqual(tv_value, 0, "TV should be >= 0.")
         self.assertLessEqual(tv_value, 1, "TV should be <= 1.")
 
     def test_calculate_tv_different_subjects(self):
         """Test calculate_TV with different subject columns."""
-        tv_sensor1 = calculate_TV(self.data, subject_no=0)
-        tv_sensor2 = calculate_TV(self.data, subject_no=1)
+        tv_sensor1 = calculate_TV(self.data, col=0)
+        tv_sensor2 = calculate_TV(self.data, col=1)
         self.assertNotEqual(
             tv_sensor1,
             tv_sensor2,
@@ -513,12 +513,12 @@ class TestCalculateTV(unittest.TestCase):
         with self.assertRaises(
             ValueError, msg="Function should raise IndexError for an empty DataFrame."
         ):
-            calculate_TV(empty_data, subject_no=0)
+            calculate_TV(empty_data, col=0)
 
     def test_calculate_tv_single_row(self):
         """Test calculate_TV with a single row of data."""
         single_row_data = self.data.iloc[:1]
-        tv_value = calculate_TV(single_row_data, subject_no=0)
+        tv_value = calculate_TV(single_row_data, col=0)
         self.assertTrue(
             np.isnan(tv_value),
             "TV should be NaN for single-row data due to lack of variance.",
@@ -535,7 +535,7 @@ class TestCalculateTV(unittest.TestCase):
             light_day=[1, 2],
         )
 
-        tv_value = calculate_TV(constant_data, subject_no=0)
+        tv_value = calculate_TV(constant_data, col=0)
         self.assertTrue(
             np.isnan(tv_value),
             "TV should be NaN for constant data due to zero total variance.",
@@ -547,7 +547,7 @@ class TestCalculateTV(unittest.TestCase):
             IndexError,
             msg="Function should raise IndexError for an invalid subject index.",
         ):
-            calculate_TV(self.data, subject_no=10)
+            calculate_TV(self.data, col=10)
 
 
 if __name__ == "__main_":

--- a/tests/episode_finder_tests.py
+++ b/tests/episode_finder_tests.py
@@ -41,7 +41,7 @@ class TestFindEpisodes(unittest.TestCase):
 
     def test_default_behavior(self):
         # Default min_length="1s" and max_interruption="0s"
-        episodes = find_episodes(self.data, subject_no=0)
+        episodes = find_episodes(self.data, col=0)
         expected_values = self.expected_values_default
         expected_index = self.expected_index_default
         pd.testing.assert_series_equal(
@@ -52,7 +52,7 @@ class TestFindEpisodes(unittest.TestCase):
 
     def test_min_length(self):
         # Test with a longer min_length
-        episodes = find_episodes(self.data, subject_no=0, min_length="20s")
+        episodes = find_episodes(self.data, col=0, min_length="20s")
         expected_index = self.expected_index_default[1::2]
         expected_values = [x for x in self.expected_values_default if x >= 20]
         pd.testing.assert_series_equal(
@@ -63,7 +63,7 @@ class TestFindEpisodes(unittest.TestCase):
 
     def test_max_interruption(self):
         # Test with a max_interruption allowing merging
-        episodes = find_episodes(self.data, subject_no=0, max_interruption="30s")
+        episodes = find_episodes(self.data, col=0, max_interruption="30s")
         expected_index = self.expected_index_default[::2]
         expected_values = [
             self.expected_values_default[i] + self.expected_values_default[i + 1] + 30
@@ -78,7 +78,7 @@ class TestFindEpisodes(unittest.TestCase):
     def test_min_length_and_max_interruption(self):
         # Test with both min_length and max_interruption
         episodes = find_episodes(
-            self.data, subject_no=1, min_length="20s", max_interruption="10s"
+            self.data, col=1, min_length="20s", max_interruption="10s"
         )
         expected_index = self.data.index[1::10]
         expected_index.freq = None
@@ -91,7 +91,7 @@ class TestFindEpisodes(unittest.TestCase):
 
     def test_no_valid_episodes(self):
         # Test with no episodes meeting min_length criteria
-        episodes = find_episodes(self.data, subject_no=1, min_length="100s")
+        episodes = find_episodes(self.data, col=1, min_length="100s")
         self.assertTrue(episodes.empty)
 
     def test_empty_data(self):
@@ -100,14 +100,14 @@ class TestFindEpisodes(unittest.TestCase):
 
         # Should raise ValueError from validate_input decorator
         with self.assertRaises(ValueError) as context:
-            find_episodes(empty_data, subject_no=0)
+            find_episodes(empty_data, col=0)
 
         # Check error message mentions NaN
         self.assertIn("NaN", str(context.exception))
 
     def test_large_max_interruption(self):
         # Test with a very large max_interruption that merges all episodes
-        episodes = find_episodes(self.data, subject_no=0, max_interruption="100s")
+        episodes = find_episodes(self.data, col=0, max_interruption="100s")
         expected_index = self.expected_index_default[0:1]
         expected_values = [460]
         pd.testing.assert_series_equal(

--- a/tests/periodogram_tests.py
+++ b/tests/periodogram_tests.py
@@ -21,7 +21,7 @@ class TestLombScarglePeriod(unittest.TestCase):
     def test_valid_input(self):
         """Test the function with valid input."""
         result = lomb_scargle_period(
-            self.data, subject_no=0, low_period=20, high_period=30
+            self.data, col=0, low_period=20, high_period=30
         )
         self.assertIn("Pmax", result)
         self.assertIn("Period", result)
@@ -29,10 +29,10 @@ class TestLombScarglePeriod(unittest.TestCase):
         self.assertGreater(result["Pmax"], 0)
         self.assertEqual(24, np.round(result["Period"]))
 
-    def test_invalid_subject_no(self):
-        """Test with an invalid subject_no."""
+    def test_invalid_col(self):
+        """Test with an invalid col."""
         with self.assertRaises(IndexError):
-            lomb_scargle_period(self.data, subject_no=10)
+            lomb_scargle_period(self.data, col=10)
 
     def test_low_period_greater_than_high_period(self):
         """Test with low_period >= high_period."""
@@ -53,7 +53,7 @@ class TestLombScarglePeriod(unittest.TestCase):
 
         # Should raise ValueError from validate_input decorator
         with self.assertRaises(ValueError) as context:
-            lomb_scargle_period(nan_data, subject_no=0)
+            lomb_scargle_period(nan_data, col=0)
 
         # Check error message mentions NaN
         self.assertIn("NaN", str(context.exception))
@@ -63,13 +63,13 @@ class TestLombScarglePeriod(unittest.TestCase):
         constant_data = pd.DataFrame(
             {"sensor1": [1] * len(self.data)}, index=self.data.index
         )
-        result = lomb_scargle_period(constant_data, subject_no=0)
+        result = lomb_scargle_period(constant_data, col=0)
         self.assertTrue(result["Pmax"] < 0.1)
 
     def test_power_values_structure(self):
         """Test that Power_values is a non-empty pd.Series with the correct index."""
         result = lomb_scargle_period(
-            self.data, subject_no=0, low_period=20, high_period=30
+            self.data, col=0, low_period=20, high_period=30
         )
         power_values = result["Power_values"]
         self.assertIsInstance(power_values, pd.DataFrame)
@@ -83,7 +83,7 @@ class TestLombScarglePeriod(unittest.TestCase):
         data = self.data
         data_circ = set_circadian_time(data, period="28h")
         result = lomb_scargle_period(
-            data_circ, subject_no=0, low_period=20, high_period=30
+            data_circ, col=0, low_period=20, high_period=30
         )
         self.assertTrue(result["Period"] < 21)
 
@@ -99,7 +99,7 @@ class TestLombScarglePeriod(unittest.TestCase):
 
         # Should raise ValueError from validate_input decorator
         with self.assertRaises(ValueError) as context:
-            lomb_scargle_period(test_data, subject_no=0)
+            lomb_scargle_period(test_data, col=0)
 
         # Check error message mentions NaN
         self.assertIn("NaN", str(context.exception))
@@ -116,7 +116,7 @@ class TestLombScarglePeriod(unittest.TestCase):
 
         # Should raise ValueError from validate_input decorator
         with self.assertRaises(ValueError) as context:
-            lomb_scargle_period(test_data, subject_no=0)
+            lomb_scargle_period(test_data, col=0)
 
         # Check error message mentions NaN
         self.assertIn("NaN", str(context.exception))
@@ -130,7 +130,7 @@ class TestLombScarglePeriod(unittest.TestCase):
 
         # Should raise ValueError from validate_input decorator
         with self.assertRaises(ValueError) as context:
-            lomb_scargle_period(test_data, subject_no=0)
+            lomb_scargle_period(test_data, col=0)
 
         # Check error message mentions NaN
         self.assertIn("NaN", str(context.exception))
@@ -143,7 +143,7 @@ class TestLombScarglePeriod(unittest.TestCase):
 
         # Should raise ValueError from validate_input decorator
         with self.assertRaises(ValueError) as context:
-            lomb_scargle_period(test_data, subject_no=0)
+            lomb_scargle_period(test_data, col=0)
 
         # Check error message mentions NaN
         self.assertIn("NaN", str(context.exception))
@@ -161,7 +161,7 @@ class TestLombScarglePeriod(unittest.TestCase):
         clean_data = test_data.ffill()
 
         # Should succeed without raising ValueError
-        result = lomb_scargle_period(clean_data, subject_no=0)
+        result = lomb_scargle_period(clean_data, col=0)
         self.assertIn("Pmax", result)
         self.assertIn("Period", result)
         self.assertIn("Power_values", result)

--- a/tests/plots_tests.py
+++ b/tests/plots_tests.py
@@ -27,7 +27,7 @@ class TestPlotActogram(unittest.TestCase):
     def test_plot_actogram_basic(self):
         """Test that plot_actogram runs without errors on valid input."""
         data = self.test_data
-        fig, ax, params_dict = plot_actogram(data, subject_no=0, light_col=-1)
+        fig, ax, params_dict = plot_actogram(data, col=0, light_col=-1)
 
         self.assertIsInstance(
             fig, plt.Figure, "Returned fig is not a matplotlib Figure."
@@ -45,7 +45,7 @@ class TestPlotActogram(unittest.TestCase):
             index=pd.date_range("2000-01-01", periods=0, freq="10min"),
         )
         with self.assertRaises(ValueError):
-            plot_actogram(empty_data, subject_no=0, light_col=-1)
+            plot_actogram(empty_data, col=0, light_col=-1)
 
     def test_plot_actogram_single_day(self):
         """Test for single day of data"""
@@ -55,7 +55,7 @@ class TestPlotActogram(unittest.TestCase):
         end = start + pd.Timedelta("24h")
         single_day_data = self.test_data.loc[start:end]
         fig, ax, params_dict = plot_actogram(
-            single_day_data, subject_no=0, light_col=-1
+            single_day_data, col=0, light_col=-1
         )
         self.assertIsInstance(
             fig, plt.Figure, "Single-day test failed to produce a valid figure."
@@ -66,17 +66,17 @@ class TestPlotActogram(unittest.TestCase):
         data = self.test_data
 
         with self.assertRaises(IndexError):
-            # Invalid subject_no
-            plot_actogram(data, subject_no=10, light_col=-1)
+            # Invalid col
+            plot_actogram(data, col=10, light_col=-1)
 
         with self.assertRaises(IndexError):
             # Invalid light_col
-            plot_actogram(data, subject_no=0, light_col=10)
+            plot_actogram(data, col=0, light_col=10)
 
     def test_plot_actogram_output_labels(self):
         """Test that the plot includes expected labels and titles."""
         data = self.test_data
-        fig, ax, params_dict = plot_actogram(data, subject_no=0, light_col=-1)
+        fig, ax, params_dict = plot_actogram(data, col=0, light_col=-1)
 
         # Check defaults in params_dict
         self.assertEqual(params_dict["xlabel"], "Time", "X-axis label mismatch.")
@@ -88,7 +88,7 @@ class TestPlotActogram(unittest.TestCase):
     def test_plot_actogram_multiple_days(self):
         """Test that plotting works for multiple days."""
         data = self.test_data
-        fig, ax, params_dict = plot_actogram(data, subject_no=0, light_col=-1)
+        fig, ax, params_dict = plot_actogram(data, col=0, light_col=-1)
 
         days_count = len(data.index.normalize().unique()) + 1
         self.assertEqual(
@@ -104,7 +104,7 @@ class TestPlotActogram(unittest.TestCase):
         subplot = ax[1]
         fig, ax, params_dict = plot_actogram(
             data,
-            subject_no=0,
+            col=0,
             light_col=-1,
             fig=fig,
             subplot=subplot,
@@ -122,7 +122,7 @@ class TestPlotActogram(unittest.TestCase):
         data_hours = data.resample("1h").mean()
 
         for curr_data in data_mins, data_hours:
-            fix, ax, params_dict = plot_actogram(curr_data, subject_no=0, light_col=-1)
+            fix, ax, params_dict = plot_actogram(curr_data, col=0, light_col=-1)
 
             days_count = len(curr_data.index.normalize().unique()) + 1
             self.assertEqual(


### PR DESCRIPTION
Summary
Addresses three open issues from the backlog.

#49 — Add docs link to README
Added a link to the full Sphinx documentation at circapy.readthedocs.io in the README, above the existing Streamlit interactive website link.

#41 — Standardise column selection parameter name
Renamed subject_no → col across all functions that accept a column index, to match the existing convention in plot_activity_profile:

- plot_actogram (plots.py)
- calculate_TV (activity.py)
- find_episodes (episodes.py)
- lomb_scargle_period (periodogram.py)
- Updated all docstrings, error messages, and tests accordingly. All 99 tests pass.

#30 — fillna FutureWarning
Investigated — already resolved in PR #26. No changes needed.